### PR TITLE
'Cannot get site to run - Error with Plyr and SSR' Fix

### DIFF
--- a/src/components/block/TextMedia.astro
+++ b/src/components/block/TextMedia.astro
@@ -240,7 +240,7 @@ const hasEmbed = !!media?.video_id?.trim() || false;
 
 {
   hasEmbed && (
-    <VideoDialog client:idle video_id={media?.video_id} embed={media?.embed}>
+    <VideoDialog client:only video_id={media?.video_id} embed={media?.embed}>
       <Icon name="close" class="w-6" />
     </VideoDialog>
   )

--- a/src/components/hero/HeroFunnel.astro
+++ b/src/components/hero/HeroFunnel.astro
@@ -204,7 +204,7 @@ const mediaClass = () => {
 {
   hasEmbed && (
     <VideoDialog
-      client:idle
+      client:only
       video_id={hero?.media?.video_id}
       embed={hero?.media?.embed}
     >


### PR DESCRIPTION
![image](https://github.com/unfolding-io/StarFunnel/assets/54600529/bc255524-a558-477a-82f9-ba191b791197)

When attempting to load the TextMedia.astro and HeroFunnel.astro components, the VideoDialog component, which utilizes Plyr.js, encounters an issue on Linux where it fails to access the document. This problem has been reported and is associated with the error documented in https://github.com/sampotts/plyr/issues/1947.

As a temporary solution, it has been observed that using client:only instead of client:idle resolves the issue. This workaround has proven effective until a more comprehensive fix is implemented.